### PR TITLE
Rename scraper() to scrapePage()

### DIFF
--- a/packages/scraper/src/index.ts
+++ b/packages/scraper/src/index.ts
@@ -1,6 +1,6 @@
 import puppeteer, {Browser, Page} from 'puppeteer'
 
-async function scraper(page : Page) {
+async function scrapePage(page : Page) {
     console.log((await page.$eval('#productTitle', (el) => el.innerHTML)).trim())
 }
 
@@ -12,7 +12,7 @@ function runScraper(url : string) {
         browser = result
         const page = await browser.newPage()
         await page.goto(url)
-        await scraper(page)
+        await scrapePage(page)
     }).catch((e) => {
         console.error(e)
     }).finally(async () => {


### PR DESCRIPTION
This name change (scraper() -> scrapePage() ) better indicates that this is an action, not a constructor or factory, and indicates what the scrape is performed on.